### PR TITLE
Added a more detailed API usage documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@ It also makes it easy for you to:
 
 #. Not repeat the boto3 boilerplate code;
 #. Define default values;
-#. Use os.environ as fall back;
+#. Use os.environ when necessary;
 
 
 Why
@@ -21,7 +21,17 @@ Why
 - Single place to save all secrets (AWS Secrets Manager)
 - Keep sensitive information away from code and environments
 - Simpler API to access AWS Secrets Manager (rather than boto3)
+- Extention of [Python Decouple](https://github.com/henriquebastos/python-decouple)
 
+Sequence
+------------
+
+```
+                      ---> ENV ---> AWS ---> DEFAULT_VALUE
+                    /
+secret = config('MY_SECRET', 'my-default-value')
+
+```
 
 Installation
 ------------
@@ -30,17 +40,17 @@ Installation
     pip install python-decouple-aws
 
 
-Usage example 1
+Usage
 ---------------
+
+## Example 1
+
 ::
 
     #  settings.py
     from decouple_aws import get_config
 
-    # The package provides a wrapper function that will
-    # fallback to environment variables and fail gracefully
-    # if AWS Secrets Manager is not accessible for whatever
-    # reason.
+    # Get the dict from AWS and make it avaible on config
     config = get_config('your-project/secret/name', 'ap-southeast-2')
 
     # Use decouple config like normal
@@ -48,20 +58,56 @@ Usage example 1
     MY_EMAIL_PASS = config('MY_EMAIL_PASS')
 
 
-Usage example 2
----------------
+## Example 2
+
+You want to run locally or on CI server with NO AWS CREDENTIALS,
+fallback to environment variables and fail gracefully
+if AWS Secrets Manager is not accessible for whatever reason.
+
 ::
 
-    # settings.py
-    from decouple import Config
-    from decouple_aws import RepositoryAwsSecretManager
+    $ export MY_EMAIL_PASS="MY-LOCAL-PASSWORD"
 
-    # if you would like it to fail if secrets
-    # manager is inaccessible, you can build it manually.
-    # initialise the config with the AWS repository
-    # Pass the repo your secret name and the region
-    repo = RepositoryAwsSecretManager('your-project/secret/name', 'ap-southeast-2')
-    config = Config(repo)
+    #  settings.py
+    from decouple_aws import get_config
+
+    config = get_config('your-project/secret/name', 'ap-southeast-2')
+
+    # Use decouple config like normal
+    MY_EMAIL_USER = config('MY_EMAIL_USER', 'default-user')
+    MY_EMAIL_PASS = config('MY_EMAIL_PASS')
+
+
+## Example 3
+
+You want to handle errors your self whatever reason.
+
+::
+
+    #  settings.py
+    from decouple_aws import get_config
+    from botocore.exceptions import NoCredentialsError
+
+    config = get_config('your-project/secret/name', 'ap-southeast-2', fail=True)
 
     # Use decouple config like normal
     MY_SUPER_SECRET_SETTING = config('MY_SUPER_SECRET_SETTING')
+                \
+        It will raise NoCredentialsError
+        when credentials is not found
+
+## Example 4
+
+whatever fail=True or failt=False, it will fail when the secret is invalid
+
+::
+
+    #  settings.py
+    from decouple_aws import get_config
+    from decouple import UndefinedValueError
+
+    config = get_config('your-project/secret/name', 'ap-southeast-2')
+    MY_SECRET = config('MY_SECRET_NOT_SET')
+                   \
+        It will raise UndefinedValueError
+        when credentials is okay but not secret registed


### PR DESCRIPTION
This README updated should explain better the changes of the PR:
https://github.com/AzMoo/python-decouple-aws/pull/5

The main idea is having a single API which can handle errors or NOT. In this way the **api users won't need to know about the RepositoryAwsSecretManager** class.